### PR TITLE
[API] Buscar produtos por categoria

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DB_HOST=localhost
+DB_HOST=db
 DB_PORT=5432
 DB_USERNAME=pguser
 DB_PASSWORD=pgpwd

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DB_HOST=db
+DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=pguser
 DB_PASSWORD=pgpwd

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
@@ -8,7 +8,7 @@ import { ICategoriaUseCase } from '../../../../../../domain/ports/categoria/ICat
 // Listagem de categorias como retorna do banco
 const todasAsCategorias: Categoria[] = [
   {
-    id: '1',
+    id: 1,
     ativo: true,
     descricao: 'Lanches de todos os tipos',
     nome: 'Lanche',
@@ -18,7 +18,7 @@ const todasAsCategorias: Categoria[] = [
     produtos: [],
   },
   {
-    id: '2',
+    id: 2,
     ativo: true,
     descricao: 'Bebidas de todos os tipos',
     nome: 'Bebidas',
@@ -28,7 +28,7 @@ const todasAsCategorias: Categoria[] = [
     produtos: [],
   },
   {
-    id: '3',
+    id: 3,
     ativo: true,
     descricao: 'Acompanhamento de todos os tipos',
     nome: 'Acompanhamento',
@@ -127,7 +127,7 @@ describe('CategoriaController', () => {
 
   describe('findOneOrFail', () => {
     it('Deve ser retornada uma categoria', async () => {
-      const categorias = await categoriaController.listaUma('1');
+      const categorias = await categoriaController.listaUma(1);
       expect(categorias).toEqual(todasAsCategorias[1]);
       expect(categoriaUseCase.listaUma).toHaveBeenCalledTimes(1);
     });
@@ -136,7 +136,7 @@ describe('CategoriaController', () => {
       jest
         .spyOn(categoriaUseCase, 'listaUma')
         .mockRejectedValueOnce(new Error());
-      expect(categoriaController.listaUma('1')).rejects.toThrowError();
+      expect(categoriaController.listaUma(1)).rejects.toThrowError();
       expect(categoriaUseCase.listaUma).toHaveBeenCalledTimes(1);
     });
   });
@@ -149,13 +149,13 @@ describe('CategoriaController', () => {
       };
       const categoriaAtualizar = new AtualizaCategoriaDTO(atualizacaoCategoria);
       const categoriaAtualizada = await categoriaController.atualiza(
-        '1',
+        1,
         categoriaAtualizar,
       );
       expect(categoriaAtualizada).toEqual(categoriaEntidadeAtualizada);
       expect(categoriaUseCase.atualiza).toHaveBeenCalledTimes(1);
       expect(categoriaUseCase.atualiza).toHaveBeenCalledWith(
-        '1',
+        1,
         categoriaAtualizar,
       );
     });
@@ -169,20 +169,20 @@ describe('CategoriaController', () => {
       jest
         .spyOn(categoriaUseCase, 'atualiza')
         .mockRejectedValueOnce(new Error());
-      expect(categoriaController.atualiza('1', body)).rejects.toThrowError();
+      expect(categoriaController.atualiza(1, body)).rejects.toThrowError();
       expect(categoriaUseCase.atualiza).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('remove', () => {
     it('Deve ser possível remover uma categoria com sucesso', async () => {
-      const result = await categoriaController.remove('1');
+      const result = await categoriaController.remove(1);
       expect(result).toBeUndefined();
     });
 
     it('Deve ser retornada uma exceção em caso de erros ao remover uma categoria', async () => {
       jest.spyOn(categoriaUseCase, 'remove').mockRejectedValueOnce(new Error());
-      expect(categoriaController.remove('1')).rejects.toThrowError();
+      expect(categoriaController.remove(1)).rejects.toThrowError();
     });
   });
 });

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
@@ -3,7 +3,7 @@ import { CategoriaController } from './categorias.controller';
 import { AtualizaCategoriaDTO } from '../../presenters/dto/categoria/AtualizaCategoria.dto';
 import { CriaCategoriaDTO } from '../../presenters/dto/categoria/CriaCategoria.dto';
 import { Categoria } from '../../../../../../domain/entities/Categoria';
-import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
+import { ICategoriaUseCase } from '../../../../../../domain/ports/categoria/ICategoriaUseCase';
 
 // Listagem de categorias como retorna do banco
 const todasAsCategorias: Categoria[] = [

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
@@ -144,7 +144,6 @@ describe('CategoriaController', () => {
   describe('atualiza', () => {
     it('Deve ser possível atualizar uma categoria com sucesso', async () => {
       const atualizacaoCategoria = {
-        descricao: 'Lanches para todos os tipos - Atualizado',
         nome: 'Lanche Atualizado ',
       };
       const categoriaAtualizar = new AtualizaCategoriaDTO(atualizacaoCategoria);
@@ -161,15 +160,14 @@ describe('CategoriaController', () => {
     });
 
     it('Deve ser lançada uma exceção em caso de erro ao atualizar uma categoria', async () => {
-      const body: AtualizaCategoriaDTO = {
-        descricao: 'Lanches para todos os tipos - Atualizado',
-        nome: 'Lanche Atualizado ',
+      const data = {
         ativo: false,
       };
+      const atualiza = new AtualizaCategoriaDTO(data);
       jest
         .spyOn(categoriaUseCase, 'atualiza')
         .mockRejectedValueOnce(new Error());
-      expect(categoriaController.atualiza(1, body)).rejects.toThrowError();
+      expect(categoriaController.atualiza(1, atualiza)).rejects.toThrowError();
       expect(categoriaUseCase.atualiza).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
@@ -1,0 +1,188 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriaController } from './categorias.controller';
+import { AtualizaCategoriaDTO } from '../../presenters/dto/categoria/AtualizaCategoria.dto';
+import { CriaCategoriaDTO } from '../../presenters/dto/categoria/CriaCategoria.dto';
+import { Categoria } from '../../../../../../domain/entities/Categoria';
+import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
+
+// Listagem de categorias como retorna do banco
+const todasAsCategorias: Categoria[] = [
+  {
+    id: '1',
+    ativo: true,
+    descricao: 'Lanches de todos os tipos',
+    nome: 'Lanche',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+    produtos: [],
+  },
+  {
+    id: '2',
+    ativo: true,
+    descricao: 'Bebidas de todos os tipos',
+    nome: 'Bebidas',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+    produtos: [],
+  },
+  {
+    id: '3',
+    ativo: true,
+    descricao: 'Acompanhamento de todos os tipos',
+    nome: 'Acompanhamento',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+    produtos: [],
+  },
+];
+
+// Categoria baseado no DTO
+const categoriaTest = {
+  descricao: 'Lanches para todos os tipos',
+  nome: 'Lanche',
+};
+
+// Implementação da categoria (Entidade)
+const novaCategoriaEntidade = new CriaCategoriaDTO(categoriaTest);
+
+// Criação de uma categoria para teste de atualização
+const categoriaTestAtualizada = {
+  descricao: 'Lanches para todos os tipos - Atualizado',
+  nome: 'Lanche Atualizado ',
+};
+const categoriaEntidadeAtualizada = new AtualizaCategoriaDTO(
+  categoriaTestAtualizada,
+);
+
+describe('CategoriaController', () => {
+  let categoriaController: CategoriaController;
+  let categoriaUseCase: ICategoriaUseCase;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriaController],
+      providers: [
+        {
+          // Mock dos métodos do service
+          provide: ICategoriaUseCase,
+          useValue: {
+            criaNova: jest.fn().mockResolvedValue(novaCategoriaEntidade),
+            listaTodas: jest.fn().mockResolvedValue(todasAsCategorias),
+            listaUma: jest.fn().mockResolvedValue(todasAsCategorias[1]),
+            atualiza: jest.fn().mockResolvedValue(categoriaEntidadeAtualizada),
+            remove: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    // instânciando controller e service
+    categoriaController = module.get<CategoriaController>(CategoriaController);
+    categoriaUseCase = module.get<ICategoriaUseCase>(ICategoriaUseCase);
+  });
+
+  it('Deve ser definido', () => {
+    expect(categoriaController).toBeDefined();
+    expect(categoriaUseCase).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('Deve ser retornado sucesso ao cadastrar uma categoria', async () => {
+      const categoria = await categoriaController.criaNovo(
+        novaCategoriaEntidade,
+      );
+      expect(categoria).toEqual(novaCategoriaEntidade);
+      expect(categoriaUseCase.criaNova).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção em caso de erro', () => {
+      // usamos o SpyOn para forçar um retorno de erro do método create.
+      jest
+        .spyOn(categoriaUseCase, 'criaNova')
+        .mockRejectedValueOnce(new Error());
+      expect(
+        categoriaController.criaNovo(novaCategoriaEntidade),
+      ).rejects.toThrowError();
+    });
+  });
+
+  describe('findAll', () => {
+    it('Deve ser retornada todas as categorias', async () => {
+      const categorias = await categoriaController.listaTodos();
+      expect(categorias).toEqual(todasAsCategorias);
+      expect(categoriaUseCase.listaTodas).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção em caso de erro ao buscar todas as categorias', async () => {
+      jest
+        .spyOn(categoriaUseCase, 'listaTodas')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaController.listaTodos()).rejects.toThrowError();
+      expect(categoriaUseCase.listaTodas).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOneOrFail', () => {
+    it('Deve ser retornada uma categoria', async () => {
+      const categorias = await categoriaController.listaUma('1');
+      expect(categorias).toEqual(todasAsCategorias[1]);
+      expect(categoriaUseCase.listaUma).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção em caso de erro ao buscar uma categoria', async () => {
+      jest
+        .spyOn(categoriaUseCase, 'listaUma')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaController.listaUma('1')).rejects.toThrowError();
+      expect(categoriaUseCase.listaUma).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    it('Deve ser possível atualizar uma categoria com sucesso', async () => {
+      const atualizacaoCategoria = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const categoriaAtualizar = new AtualizaCategoriaDTO(atualizacaoCategoria);
+      const categoriaAtualizada = await categoriaController.atualiza(
+        '1',
+        categoriaAtualizar,
+      );
+      expect(categoriaAtualizada).toEqual(categoriaEntidadeAtualizada);
+      expect(categoriaUseCase.atualiza).toHaveBeenCalledTimes(1);
+      expect(categoriaUseCase.atualiza).toHaveBeenCalledWith(
+        '1',
+        categoriaAtualizar,
+      );
+    });
+
+    it('Deve ser lançada uma exceção em caso de erro ao atualizar uma categoria', async () => {
+      const body: AtualizaCategoriaDTO = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+        ativo: false,
+      };
+      jest
+        .spyOn(categoriaUseCase, 'atualiza')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaController.atualiza('1', body)).rejects.toThrowError();
+      expect(categoriaUseCase.atualiza).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('Deve ser possível remover uma categoria com sucesso', async () => {
+      const result = await categoriaController.remove('1');
+      expect(result).toBeUndefined();
+    });
+
+    it('Deve ser retornada uma exceção em caso de erros ao remover uma categoria', async () => {
+      jest.spyOn(categoriaUseCase, 'remove').mockRejectedValueOnce(new Error());
+      expect(categoriaController.remove('1')).rejects.toThrowError();
+    });
+  });
+});

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categoria.controller.spec.ts
@@ -89,7 +89,7 @@ describe('CategoriaController', () => {
     expect(categoriaUseCase).toBeDefined();
   });
 
-  describe('create', () => {
+  describe('criaNovo', () => {
     it('Deve ser retornado sucesso ao cadastrar uma categoria', async () => {
       const categoria = await categoriaController.criaNovo(
         novaCategoriaEntidade,
@@ -109,7 +109,7 @@ describe('CategoriaController', () => {
     });
   });
 
-  describe('findAll', () => {
+  describe('listaTodos', () => {
     it('Deve ser retornada todas as categorias', async () => {
       const categorias = await categoriaController.listaTodos();
       expect(categorias).toEqual(todasAsCategorias);
@@ -125,7 +125,7 @@ describe('CategoriaController', () => {
     });
   });
 
-  describe('findOneOrFail', () => {
+  describe('listaUma', () => {
     it('Deve ser retornada uma categoria', async () => {
       const categorias = await categoriaController.listaUma(1);
       expect(categorias).toEqual(todasAsCategorias[1]);
@@ -141,7 +141,7 @@ describe('CategoriaController', () => {
     });
   });
 
-  describe('update', () => {
+  describe('atualiza', () => {
     it('Deve ser possível atualizar uma categoria com sucesso', async () => {
       const atualizacaoCategoria = {
         descricao: 'Lanches para todos os tipos - Atualizado',

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categorias.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categorias.controller.ts
@@ -12,7 +12,7 @@ import {
 
 import { AtualizaCategoriaDTO } from '../../presenters/dto/categoria/AtualizaCategoria.dto';
 import { CriaCategoriaDTO } from '../../presenters/dto/categoria/CriaCategoria.dto';
-import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
+import { ICategoriaUseCase } from '../../../../../../domain/ports/categoria/ICategoriaUseCase';
 
 @Controller('categorias')
 export class CategoriaController {

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categorias.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categorias.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   Inject,
   Param,
-  ParseUUIDPipe,
   Post,
   Put,
 } from '@nestjs/common';
@@ -32,20 +31,20 @@ export class CategoriaController {
   }
 
   @Get(':id')
-  async listaUma(@Param('id', new ParseUUIDPipe()) id: string) {
+  async listaUma(@Param('id') id: number) {
     return await this.CategoriaUseCase.listaUma(id);
   }
 
   @Put('/:id')
   async atualiza(
-    @Param('id', new ParseUUIDPipe()) id: string,
+    @Param('id') id: number,
     @Body() dadosCategoria: AtualizaCategoriaDTO,
   ) {
     return await this.CategoriaUseCase.atualiza(id, dadosCategoria);
   }
 
   @Delete('/:id')
-  async remove(@Param('id') id: string) {
+  async remove(@Param('id') id: number) {
     return await this.CategoriaUseCase.remove(id);
   }
 }

--- a/src/adapters/inbound/rest/v1/controllers/categorias/categorias.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/categorias/categorias.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Inject,
   Param,
+  ParseUUIDPipe,
   Post,
   Put,
 } from '@nestjs/common';
@@ -22,37 +23,29 @@ export class CategoriaController {
 
   @Post()
   async criaNovo(@Body() dadosCategoria: CriaCategoriaDTO) {
-    return this.CategoriaUseCase.criaNova(dadosCategoria);
+    return await this.CategoriaUseCase.criaNova(dadosCategoria);
   }
 
   @Get()
   async listaTodos() {
-    return this.CategoriaUseCase.listaTodas();
+    return await this.CategoriaUseCase.listaTodas();
+  }
+
+  @Get(':id')
+  async listaUma(@Param('id', new ParseUUIDPipe()) id: string) {
+    return await this.CategoriaUseCase.listaUma(id);
   }
 
   @Put('/:id')
   async atualiza(
-    @Param('id') id: number,
+    @Param('id', new ParseUUIDPipe()) id: string,
     @Body() dadosCategoria: AtualizaCategoriaDTO,
   ) {
-    const categoriaAlterada = await this.CategoriaUseCase.atualiza(
-      id,
-      dadosCategoria,
-    );
-
-    return {
-      mensagem: 'categoria atualizada com sucesso',
-      categoria: categoriaAlterada,
-    };
+    return await this.CategoriaUseCase.atualiza(id, dadosCategoria);
   }
 
   @Delete('/:id')
-  async remove(@Param('id') id: number) {
-    const categoriaRemovida = await this.CategoriaUseCase.remove(id);
-
-    return {
-      mensagem: 'categoria removida com sucesso',
-      categoria: categoriaRemovida,
-    };
+  async remove(@Param('id') id: string) {
+    return await this.CategoriaUseCase.remove(id);
   }
 }

--- a/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
@@ -11,7 +11,7 @@ import {
 
 import { AtualizaProdutoDTO } from '../../presenters/dto/produto/AtualizaProduto.dto';
 import { CriaProdutoDTO } from '../../presenters/dto/produto/CriaProduto.dto';
-import { IProdutoUseCase } from 'src/domain/ports/produto/IProdutoUseCase';
+import { IProdutoUseCase } from '../../../../../../domain/ports/produto/IProdutoUseCase';
 
 @Controller('produtos')
 export class ProdutoController {
@@ -28,6 +28,11 @@ export class ProdutoController {
   @Get()
   async listaTodos() {
     return this.produtoUseCase.listaTodos();
+  }
+
+  @Get('categorias/:id')
+  async listaPorCategoria(@Param('categoriaId') categoriaId: string) {
+    return await this.produtoUseCase.listaPorCategoria(categoriaId);
   }
 
   @Put('/:id')

--- a/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
@@ -31,7 +31,7 @@ export class ProdutoController {
   }
 
   @Get('/categoria/:id')
-  async listaTodosPorCategoria(@Param('id') id_categoria: string) {
+  async listaTodosPorCategoria(@Param('id') id_categoria: number) {
     return this.produtoUseCase.listaPorCategoria(id_categoria);
   }
 

--- a/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
@@ -11,7 +11,7 @@ import {
 
 import { AtualizaProdutoDTO } from '../../presenters/dto/produto/AtualizaProduto.dto';
 import { CriaProdutoDTO } from '../../presenters/dto/produto/CriaProduto.dto';
-import { IProdutoUseCase } from '../../../../../../domain/ports/produto/IProdutoUseCase';
+import { IProdutoUseCase } from 'src/domain/ports/produto/IProdutoUseCase';
 
 @Controller('produtos')
 export class ProdutoController {
@@ -30,9 +30,9 @@ export class ProdutoController {
     return this.produtoUseCase.listaTodos();
   }
 
-  @Get('categorias/:id')
-  async listaPorCategoria(@Param('categoriaId') categoriaId: string) {
-    return await this.produtoUseCase.listaPorCategoria(categoriaId);
+  @Get('/categoria/:id')
+  async listaTodosPorCategoria(@Param('id') id_categoria: string) {
+    return this.produtoUseCase.listaPorCategoria(id_categoria);
   }
 
   @Put('/:id')

--- a/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
+++ b/src/adapters/inbound/rest/v1/controllers/produtos/produtos.controller.ts
@@ -27,12 +27,12 @@ export class ProdutoController {
 
   @Get()
   async listaTodos() {
-    return this.produtoUseCase.listaTodos();
+    return await this.produtoUseCase.listaTodos();
   }
 
   @Get('/categoria/:id')
   async listaTodosPorCategoria(@Param('id') id_categoria: number) {
-    return this.produtoUseCase.listaPorCategoria(id_categoria);
+    return await this.produtoUseCase.listaPorCategoria(id_categoria);
   }
 
   @Put('/:id')

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
@@ -1,28 +1,3 @@
-import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { CriaCategoriaDTO } from './CriaCategoria.dto';
 
-export class AtualizaCategoriaDTO {
-  constructor(categoria?: {
-    nome?: string;
-    descricao?: string;
-    ativo?: boolean;
-  }) {
-    this.nome = categoria.nome;
-    this.descricao = categoria.descricao;
-    this.ativo = categoria.ativo;
-  }
-
-  @IsString()
-  @IsNotEmpty({ message: 'Nome da categoria não pode ser vazio' })
-  nome: string;
-
-  @IsString()
-  @IsNotEmpty({ message: 'Descrição da categoria não pode ser vazia' })
-  @MaxLength(1000, {
-    message: 'Descrição não pode ter mais que 1000 caracteres',
-  })
-  descricao: string;
-
-  @IsBoolean()
-  @IsNotEmpty({ message: 'Ativo não pode ser vazio' })
-  ativo: boolean;
-}
+export class AtualizaCategoriaDTO extends CriaCategoriaDTO {}

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
@@ -1,16 +1,14 @@
 import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-interface IAtualizaCategoria {
-  nome?: string;
-  descricao?: string;
-  ativo?: boolean;
-}
-
 export class AtualizaCategoriaDTO {
-  constructor(categoria?: Partial<IAtualizaCategoria>) {
-    this.nome = categoria?.nome;
-    this.descricao = categoria?.descricao;
-    this.ativo = categoria?.ativo;
+  constructor(categoria?: {
+    nome?: string;
+    descricao?: string;
+    ativo?: boolean;
+  }) {
+    this.nome = categoria.nome;
+    this.descricao = categoria.descricao;
+    this.ativo = categoria.ativo;
   }
 
   @IsString()

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
@@ -1,3 +1,28 @@
-import { CriaCategoriaDTO } from './CriaCategoria.dto';
+import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-export class AtualizaCategoriaDTO extends CriaCategoriaDTO {}
+export class AtualizaCategoriaDTO {
+  constructor(categoria?: {
+    nome?: string;
+    descricao?: string;
+    ativo?: boolean;
+  }) {
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+    this.ativo = categoria?.ativo;
+  }
+
+  @IsString()
+  @IsNotEmpty({ message: 'Nome da categoria não pode ser vazio' })
+  nome: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'Descrição da categoria não pode ser vazia' })
+  @MaxLength(1000, {
+    message: 'Descrição não pode ter mais que 1000 caracteres',
+  })
+  descricao: string;
+
+  @IsBoolean()
+  @IsNotEmpty({ message: 'Ativo não pode ser vazio' })
+  ativo: boolean;
+}

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto.ts
@@ -1,6 +1,18 @@
 import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
+interface IAtualizaCategoria {
+  nome?: string;
+  descricao?: string;
+  ativo?: boolean;
+}
+
 export class AtualizaCategoriaDTO {
+  constructor(categoria?: Partial<IAtualizaCategoria>) {
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+    this.ativo = categoria?.ativo;
+  }
+
   @IsString()
   @IsNotEmpty({ message: 'Nome da categoria não pode ser vazio' })
   nome: string;

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto.ts
@@ -1,12 +1,7 @@
 import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-interface ICriaCategoriaDTO {
-  nome: string;
-  descricao: string;
-}
-
 export class CriaCategoriaDTO {
-  constructor(categoria?: ICriaCategoriaDTO) {
+  constructor(categoria?: { nome: string; descricao: string }) {
     this.nome = categoria?.nome;
     this.descricao = categoria?.descricao;
   }

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto.ts
@@ -1,6 +1,15 @@
 import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
+interface ICriaCategoriaDTO {
+  nome: string;
+  descricao: string;
+}
+
 export class CriaCategoriaDTO {
+  constructor(categoria?: ICriaCategoriaDTO) {
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+  }
   @IsString()
   @IsNotEmpty({ message: 'Nome da categoria não pode ser vazio' })
   nome: string;
@@ -14,5 +23,5 @@ export class CriaCategoriaDTO {
 
   @IsBoolean()
   @IsNotEmpty({ message: 'Ativo não pode ser vazio' })
-  ativo: boolean;
+  ativo: boolean = true;
 }

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto.ts
@@ -1,9 +1,9 @@
 import { IsBoolean, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class CriaCategoriaDTO {
-  constructor(categoria?: { nome: string; descricao: string }) {
-    this.nome = categoria?.nome;
-    this.descricao = categoria?.descricao;
+  constructor(categoria: { nome?: string; descricao?: string }) {
+    this.nome = categoria.nome;
+    this.descricao = categoria.descricao;
   }
   @IsString()
   @IsNotEmpty({ message: 'Nome da categoria não pode ser vazio' })

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
@@ -1,8 +1,16 @@
+interface IListaCategoria {
+  id: string;
+  nome: string;
+  descricao: string;
+}
+
 export class ListaCategoriaDTO {
-  constructor(
-    readonly id: number,
-    readonly nome: string,
-    readonly descricao: string,
-    readonly ativo: boolean,
-  ) {}
+  readonly id: string;
+  readonly nome: string;
+  readonly descricao: string;
+  constructor(categoria?: Partial<IListaCategoria>) {
+    this.id = categoria?.id;
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+  }
 }

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
@@ -1,14 +1,8 @@
-interface IListaCategoria {
-  id: number;
-  nome: string;
-  descricao: string;
-}
-
 export class ListaCategoriaDTO {
   readonly id: number;
   readonly nome: string;
   readonly descricao: string;
-  constructor(categoria?: Partial<IListaCategoria>) {
+  constructor(categoria?: { id: number; nome: string; descricao: string }) {
     this.id = categoria?.id;
     this.nome = categoria?.nome;
     this.descricao = categoria?.descricao;

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
@@ -2,9 +2,9 @@ export class ListaCategoriaDTO {
   readonly id: number;
   readonly nome: string;
   readonly descricao: string;
-  constructor(categoria?: { id: number; nome: string; descricao: string }) {
-    this.id = categoria?.id;
-    this.nome = categoria?.nome;
-    this.descricao = categoria?.descricao;
+  constructor(categoria: { id?: number; nome?: string; descricao?: string }) {
+    this.id = categoria.id;
+    this.nome = categoria.nome;
+    this.descricao = categoria.descricao;
   }
 }

--- a/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto.ts
@@ -1,11 +1,11 @@
 interface IListaCategoria {
-  id: string;
+  id: number;
   nome: string;
   descricao: string;
 }
 
 export class ListaCategoriaDTO {
-  readonly id: string;
+  readonly id: number;
   readonly nome: string;
   readonly descricao: string;
   constructor(categoria?: Partial<IListaCategoria>) {

--- a/src/adapters/inbound/rest/v1/presenters/dto/produto/AtualizaProduto.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/produto/AtualizaProduto.dto.ts
@@ -24,7 +24,7 @@ export class AtualizaProdutoDTO {
   @Min(1, { message: 'O valor precisa ser maior que zero' })
   valorUnitario: number;
 
-  @IsUrl({ message: 'URL para imagem inválida' })
+  @IsUrl(undefined, { message: 'URL para imagem inválida' })
   imagemUrl: string;
 
   @IsBoolean()

--- a/src/adapters/inbound/rest/v1/presenters/dto/produto/AtualizaProduto.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/produto/AtualizaProduto.dto.ts
@@ -1,39 +1,6 @@
-import {
-  IsBoolean,
-  IsNotEmpty,
-  IsNumber,
-  IsString,
-  IsUrl,
-  MaxLength,
-  Min,
-} from 'class-validator';
+import { CriaProdutoDTO } from './CriaProduto.dto';
 
-export class AtualizaProdutoDTO {
-  @IsString()
-  @IsNotEmpty({ message: 'Nome do produto não pode ser vazio' })
-  nome: string;
-
-  @IsString()
-  @IsNotEmpty({ message: 'Descrição do produto não pode ser vazia' })
-  @MaxLength(1000, {
-    message: 'Descrição não pode ter mais que 1000 caracteres',
-  })
-  descricao: string;
-
-  @IsNumber({ maxDecimalPlaces: 2, allowNaN: false, allowInfinity: false })
-  @Min(1, { message: 'O valor precisa ser maior que zero' })
-  valorUnitario: number;
-
-  @IsUrl(undefined, { message: 'URL para imagem inválida' })
-  imagemUrl: string;
-
-  @IsBoolean()
-  @IsNotEmpty({ message: 'Ativo não pode ser vazio' })
-  ativo: boolean;
-
-  @IsString()
-  idCategoria: string;
-
+export class AtualizaProdutoDTO extends CriaProdutoDTO {
   constructor(
     nome?: string,
     descricao?: string,
@@ -42,6 +9,7 @@ export class AtualizaProdutoDTO {
     ativo: boolean = true,
     idCategoria?: string,
   ) {
+    super();
     this.nome = nome;
     this.descricao = descricao;
     this.valorUnitario = valorUnitario;

--- a/src/adapters/inbound/rest/v1/presenters/dto/produto/CriaProduto.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/produto/CriaProduto.dto.ts
@@ -24,7 +24,7 @@ export class CriaProdutoDTO {
   @Min(1, { message: 'O valor precisa ser maior que zero' })
   valorUnitario: number;
 
-  @IsUrl({ message: 'URL para imagem inválida' })
+  @IsUrl(undefined, { message: 'URL para imagem inválida' })
   imagemUrl: string;
 
   @IsBoolean()

--- a/src/adapters/inbound/rest/v1/presenters/dto/produto/ListaProduto.dto.ts
+++ b/src/adapters/inbound/rest/v1/presenters/dto/produto/ListaProduto.dto.ts
@@ -1,3 +1,5 @@
+import { CategoriaModel } from 'src/adapters/outbound/models/categoria.model';
+
 export class ListaProdutoDTO {
   constructor(
     readonly id: string,
@@ -5,7 +7,7 @@ export class ListaProdutoDTO {
     readonly descricao: string,
     readonly valorUnitario: number,
     readonly imagemUrl: string,
-    readonly idCategoria: number,
+    readonly idCategoria: CategoriaModel,
     readonly ativo: boolean,
   ) {}
 }

--- a/src/adapters/outbound/models/categoria.model.ts
+++ b/src/adapters/outbound/models/categoria.model.ts
@@ -9,8 +9,27 @@ import {
 } from 'typeorm';
 import { ProdutoModel } from './produto.model';
 
+interface ICategory {
+  id: number;
+  nome: string;
+  descricao: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  ativo: boolean;
+}
+
 @Entity('categorias')
 export class CategoriaModel {
+  constructor(categoria?: Partial<ICategory>) {
+    this.id = categoria?.id;
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+    this.ativo = categoria?.ativo;
+    this.createdAt = categoria?.createdAt;
+    this.updatedAt = categoria?.updatedAt;
+    this.deletedAt = categoria?.deletedAt;
+  }
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/adapters/outbound/models/categoria.model.ts
+++ b/src/adapters/outbound/models/categoria.model.ts
@@ -9,32 +9,10 @@ import {
 } from 'typeorm';
 import { ProdutoModel } from './produto.model';
 
-interface ICategoriaModel {
-  id: string;
-  nome: string;
-  descricao: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string;
-  ativo: boolean;
-  produtos: ProdutoModel[];
-}
-
 @Entity('categorias')
 export class CategoriaModel {
-  constructor(categoria?: Partial<ICategoriaModel>) {
-    this.id = categoria?.id;
-    this.nome = categoria?.nome;
-    this.descricao = categoria?.descricao;
-    this.ativo = categoria?.ativo;
-    this.createdAt = categoria?.createdAt;
-    this.updatedAt = categoria?.updatedAt;
-    this.deletedAt = categoria?.deletedAt;
-    this.produtos = categoria?.produtos;
-  }
-
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+  @PrimaryGeneratedColumn()
+  id: number;
 
   @Column({ name: 'nome', length: 100, nullable: false })
   nome: string;

--- a/src/adapters/outbound/models/categoria.model.ts
+++ b/src/adapters/outbound/models/categoria.model.ts
@@ -9,26 +9,24 @@ import {
 } from 'typeorm';
 import { ProdutoModel } from './produto.model';
 
-interface ICategory {
-  id: number;
-  nome: string;
-  descricao: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string;
-  ativo: boolean;
-}
-
 @Entity('categorias')
 export class CategoriaModel {
-  constructor(categoria?: Partial<ICategory>) {
-    this.id = categoria?.id;
-    this.nome = categoria?.nome;
-    this.descricao = categoria?.descricao;
-    this.ativo = categoria?.ativo;
-    this.createdAt = categoria?.createdAt;
-    this.updatedAt = categoria?.updatedAt;
-    this.deletedAt = categoria?.deletedAt;
+  constructor(categoria: {
+    id?: number;
+    nome?: string;
+    descricao?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    deletedAt?: string;
+    ativo?: boolean;
+  }) {
+    this.id = categoria.id;
+    this.nome = categoria.nome;
+    this.descricao = categoria.descricao;
+    this.ativo = categoria.ativo;
+    this.createdAt = categoria.createdAt;
+    this.updatedAt = categoria.updatedAt;
+    this.deletedAt = categoria.deletedAt;
   }
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/adapters/outbound/models/categoria.model.ts
+++ b/src/adapters/outbound/models/categoria.model.ts
@@ -9,10 +9,32 @@ import {
 } from 'typeorm';
 import { ProdutoModel } from './produto.model';
 
+interface ICategoriaModel {
+  id: string;
+  nome: string;
+  descricao: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  ativo: boolean;
+  produtos: ProdutoModel[];
+}
+
 @Entity('categorias')
 export class CategoriaModel {
+  constructor(categoria?: Partial<ICategoriaModel>) {
+    this.id = categoria?.id;
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+    this.ativo = categoria?.ativo;
+    this.createdAt = categoria?.createdAt;
+    this.updatedAt = categoria?.updatedAt;
+    this.deletedAt = categoria?.deletedAt;
+    this.produtos = categoria?.produtos;
+  }
+
   @PrimaryGeneratedColumn()
-  id: number;
+  id: string;
 
   @Column({ name: 'nome', length: 100, nullable: false })
   nome: string;

--- a/src/adapters/outbound/models/categoria.model.ts
+++ b/src/adapters/outbound/models/categoria.model.ts
@@ -33,7 +33,7 @@ export class CategoriaModel {
     this.produtos = categoria?.produtos;
   }
 
-  @PrimaryGeneratedColumn()
+  @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column({ name: 'nome', length: 100, nullable: false })

--- a/src/adapters/outbound/models/categoria.model.ts
+++ b/src/adapters/outbound/models/categoria.model.ts
@@ -20,13 +20,13 @@ export class CategoriaModel {
     deletedAt?: string;
     ativo?: boolean;
   }) {
-    this.id = categoria.id;
-    this.nome = categoria.nome;
-    this.descricao = categoria.descricao;
-    this.ativo = categoria.ativo;
-    this.createdAt = categoria.createdAt;
-    this.updatedAt = categoria.updatedAt;
-    this.deletedAt = categoria.deletedAt;
+    this.id = categoria?.id;
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+    this.ativo = categoria?.ativo;
+    this.createdAt = categoria?.createdAt;
+    this.updatedAt = categoria?.updatedAt;
+    this.deletedAt = categoria?.deletedAt;
   }
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.spec.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { CategoriaModel } from '../../models/categoria.model';
+import { CategoriaRepository } from '../categoria/categoria.repository';
+import { CriaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
+import { AtualizaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
+import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto';
+
+const ListaCategoriaEntidade: CategoriaModel[] = [
+  new CategoriaModel({
+    id: '1',
+    ativo: true,
+    descricao: 'Lanches de todos os tipos',
+    nome: 'Lanche',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+  }),
+  new CategoriaModel({
+    id: '2',
+    ativo: true,
+    descricao: 'Bebidas de todos os tipos',
+    nome: 'Bebidas',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+  }),
+  new CategoriaModel({
+    id: '3',
+    ativo: true,
+    descricao: 'Acompanhamento de todos os tipos',
+    nome: 'Acompanhamento',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+  }),
+];
+
+const updateCategoriaEntidadeItem = new CategoriaModel({
+  descricao: 'Lanches para todos os tipos - Atualizado',
+  nome: 'Lanche Atualizado ',
+});
+
+describe('CategoriaRepository', () => {
+  let categoriaRepository: CategoriaRepository;
+  let categoryModel: Repository<CategoriaModel>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriaRepository,
+        {
+          provide: getRepositoryToken(CategoriaModel),
+          useValue: {
+            find: jest.fn().mockResolvedValue(ListaCategoriaEntidade),
+            findOneOrFail: jest
+              .fn()
+              .mockResolvedValue(ListaCategoriaEntidade[0]),
+            create: jest.fn().mockReturnValue(ListaCategoriaEntidade[0]),
+            save: jest.fn().mockResolvedValue(ListaCategoriaEntidade[0]),
+            merge: jest.fn().mockResolvedValue(updateCategoriaEntidadeItem),
+            softDelete: jest.fn().mockReturnValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    categoriaRepository = module.get<CategoriaRepository>(CategoriaRepository);
+    categoryModel = module.get<Repository<CategoriaModel>>(
+      getRepositoryToken(CategoriaModel),
+    );
+  });
+
+  it('should be defined', () => {
+    expect(categoriaRepository).toBeDefined();
+    expect(categoryModel).toBeDefined();
+  });
+
+  describe('listaCategorias', () => {
+    it('Deve ser retornada uma lista de entidades de todas as categorias', async () => {
+      const result = await categoriaRepository.listaCategorias();
+      const listaCategoriasEsperadas = result.map(
+        (item) => new ListaCategoriaDTO(item),
+      );
+      expect(result).toEqual(listaCategoriasEsperadas);
+      expect(categoryModel.find).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser retornada uma exceção em caso de erro', () => {
+      jest.spyOn(categoryModel, 'find').mockRejectedValueOnce(new Error());
+      expect(categoriaRepository.listaCategorias()).rejects.toThrowError();
+    });
+  });
+
+  describe('listaCategoria', () => {
+    it('Deve ser retornado um item da entidade categoria', async () => {
+      const result = await categoriaRepository.listaCategoria('1');
+      const categoriaEsperada = new ListaCategoriaDTO(
+        ListaCategoriaEntidade[0],
+      );
+      expect(result).toEqual(categoriaEsperada);
+      expect(categoryModel.findOneOrFail).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção (not found exception) em caso de erro', () => {
+      jest
+        .spyOn(categoryModel, 'findOneOrFail')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaRepository.listaCategoria('1')).rejects.toThrowError(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('criaCategoria', () => {
+    it('Deve criar uma categoria com sucesso', async () => {
+      const categoria: CriaCategoriaDTO = {
+        ativo: true,
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const result = await categoriaRepository.criaCategoria(categoria);
+      expect(result).toEqual(ListaCategoriaEntidade[0]);
+      expect(categoryModel.create).toHaveBeenCalledTimes(1);
+      expect(categoryModel.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção em caso de erro', () => {
+      const categoria: CriaCategoriaDTO = {
+        ativo: true,
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      jest.spyOn(categoryModel, 'save').mockRejectedValueOnce(new Error());
+      expect(
+        categoriaRepository.criaCategoria(categoria),
+      ).rejects.toThrowError();
+    });
+  });
+
+  describe('atualizaCategoria', () => {
+    it('Deve ser atualiza uma categoria com sucesso', async () => {
+      const data = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const atualizaCategoria = new AtualizaCategoriaDTO(data);
+      jest
+        .spyOn(categoryModel, 'save')
+        .mockResolvedValueOnce(updateCategoriaEntidadeItem);
+      const result = await categoriaRepository.atualizaCategoria(
+        '1',
+        atualizaCategoria,
+      );
+      expect(result).toEqual(updateCategoriaEntidadeItem);
+    });
+
+    it('Deve lançar uma not found exception se a categoria não existir', async () => {
+      const data = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const atualizaCategoria = new AtualizaCategoriaDTO(data);
+      jest
+        .spyOn(categoryModel, 'findOneOrFail')
+        .mockRejectedValueOnce(new NotFoundException());
+      expect(
+        categoriaRepository.atualizaCategoria('1', atualizaCategoria),
+      ).rejects.toThrowError(NotFoundException);
+    });
+
+    it('Deve lançar uma exceção quando não conseguir salvar', () => {
+      const data = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const atualizaCategoria = new AtualizaCategoriaDTO(data);
+      jest.spyOn(categoryModel, 'save').mockRejectedValueOnce(new Error());
+      expect(
+        categoriaRepository.atualizaCategoria('1', atualizaCategoria),
+      ).rejects.toThrowError();
+    });
+  });
+
+  describe('deletaCategoria', () => {
+    it('Deve ser removida a entidade da categoria com sucesso', async () => {
+      const result = await categoriaRepository.deletaCategoria('1');
+      expect(result).toBeUndefined();
+      expect(categoryModel.findOneOrFail).toHaveBeenCalledTimes(1);
+      expect(categoryModel.softDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve lançar uma not found exception se a categoria não existir', async () => {
+      jest
+        .spyOn(categoryModel, 'findOneOrFail')
+        .mockRejectedValueOnce(new NotFoundException());
+      expect(categoriaRepository.deletaCategoria('1')).rejects.toThrowError(
+        NotFoundException,
+      );
+    });
+
+    it('Deve lançar uma exception se retornar um erro ao tentar remover a categoria', async () => {
+      jest
+        .spyOn(categoryModel, 'softDelete')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaRepository.deletaCategoria('1')).rejects.toThrowError();
+    });
+  });
+});

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.spec.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.spec.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { CategoriaModel } from '../../models/categoria.model';
 import { CategoriaRepository } from '../categoria/categoria.repository';
-import { CriaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 import { AtualizaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto';
 
@@ -116,10 +115,15 @@ describe('CategoriaRepository', () => {
 
   describe('criaCategoria', () => {
     it('Deve criar uma categoria com sucesso', async () => {
-      const categoria: CriaCategoriaDTO = {
+      const categoria: CategoriaModel = {
         ativo: true,
         descricao: 'Lanches para todos os tipos - Atualizado',
         nome: 'Lanche Atualizado ',
+        id: 0,
+        createdAt: '',
+        updatedAt: '',
+        deletedAt: '',
+        produtos: [],
       };
       const result = await categoriaRepository.criaCategoria(categoria);
       expect(result).toEqual(ListaCategoriaEntidade[0]);
@@ -128,10 +132,15 @@ describe('CategoriaRepository', () => {
     });
 
     it('Deve ser lançada uma exceção em caso de erro', () => {
-      const categoria: CriaCategoriaDTO = {
+      const categoria: CategoriaModel = {
         ativo: true,
         descricao: 'Lanches para todos os tipos - Atualizado',
         nome: 'Lanche Atualizado ',
+        id: 0,
+        createdAt: '',
+        updatedAt: '',
+        deletedAt: '',
+        produtos: [],
       };
       jest.spyOn(categoryModel, 'save').mockRejectedValueOnce(new Error());
       expect(

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.spec.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.spec.ts
@@ -10,7 +10,7 @@ import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/c
 
 const ListaCategoriaEntidade: CategoriaModel[] = [
   new CategoriaModel({
-    id: '1',
+    id: 1,
     ativo: true,
     descricao: 'Lanches de todos os tipos',
     nome: 'Lanche',
@@ -19,7 +19,7 @@ const ListaCategoriaEntidade: CategoriaModel[] = [
     deletedAt: '',
   }),
   new CategoriaModel({
-    id: '2',
+    id: 2,
     ativo: true,
     descricao: 'Bebidas de todos os tipos',
     nome: 'Bebidas',
@@ -28,7 +28,7 @@ const ListaCategoriaEntidade: CategoriaModel[] = [
     deletedAt: '',
   }),
   new CategoriaModel({
-    id: '3',
+    id: 2,
     ativo: true,
     descricao: 'Acompanhamento de todos os tipos',
     nome: 'Acompanhamento',
@@ -96,7 +96,7 @@ describe('CategoriaRepository', () => {
 
   describe('listaCategoria', () => {
     it('Deve ser retornado um item da entidade categoria', async () => {
-      const result = await categoriaRepository.listaCategoria('1');
+      const result = await categoriaRepository.listaCategoria(1);
       const categoriaEsperada = new ListaCategoriaDTO(
         ListaCategoriaEntidade[0],
       );
@@ -108,7 +108,7 @@ describe('CategoriaRepository', () => {
       jest
         .spyOn(categoryModel, 'findOneOrFail')
         .mockRejectedValueOnce(new Error());
-      expect(categoriaRepository.listaCategoria('1')).rejects.toThrowError(
+      expect(categoriaRepository.listaCategoria(1)).rejects.toThrowError(
         NotFoundException,
       );
     });
@@ -151,7 +151,7 @@ describe('CategoriaRepository', () => {
         .spyOn(categoryModel, 'save')
         .mockResolvedValueOnce(updateCategoriaEntidadeItem);
       const result = await categoriaRepository.atualizaCategoria(
-        '1',
+        1,
         atualizaCategoria,
       );
       expect(result).toEqual(updateCategoriaEntidadeItem);
@@ -167,7 +167,7 @@ describe('CategoriaRepository', () => {
         .spyOn(categoryModel, 'findOneOrFail')
         .mockRejectedValueOnce(new NotFoundException());
       expect(
-        categoriaRepository.atualizaCategoria('1', atualizaCategoria),
+        categoriaRepository.atualizaCategoria(1, atualizaCategoria),
       ).rejects.toThrowError(NotFoundException);
     });
 
@@ -179,14 +179,14 @@ describe('CategoriaRepository', () => {
       const atualizaCategoria = new AtualizaCategoriaDTO(data);
       jest.spyOn(categoryModel, 'save').mockRejectedValueOnce(new Error());
       expect(
-        categoriaRepository.atualizaCategoria('1', atualizaCategoria),
+        categoriaRepository.atualizaCategoria(1, atualizaCategoria),
       ).rejects.toThrowError();
     });
   });
 
   describe('deletaCategoria', () => {
     it('Deve ser removida a entidade da categoria com sucesso', async () => {
-      const result = await categoriaRepository.deletaCategoria('1');
+      const result = await categoriaRepository.deletaCategoria(1);
       expect(result).toBeUndefined();
       expect(categoryModel.findOneOrFail).toHaveBeenCalledTimes(1);
       expect(categoryModel.softDelete).toHaveBeenCalledTimes(1);
@@ -196,7 +196,7 @@ describe('CategoriaRepository', () => {
       jest
         .spyOn(categoryModel, 'findOneOrFail')
         .mockRejectedValueOnce(new NotFoundException());
-      expect(categoriaRepository.deletaCategoria('1')).rejects.toThrowError(
+      expect(categoriaRepository.deletaCategoria(1)).rejects.toThrowError(
         NotFoundException,
       );
     });
@@ -205,7 +205,7 @@ describe('CategoriaRepository', () => {
       jest
         .spyOn(categoryModel, 'softDelete')
         .mockRejectedValueOnce(new Error());
-      expect(categoriaRepository.deletaCategoria('1')).rejects.toThrowError();
+      expect(categoriaRepository.deletaCategoria(1)).rejects.toThrowError();
     });
   });
 });

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.ts
@@ -15,8 +15,9 @@ export class CategoriaRepository implements ICategoriaRepository {
   ) {}
 
   async criaCategoria(categoria: CriaCategoriaDTO) {
+    const categoriaModel = new CategoriaModel(categoria);
     return await this.categoriaRepository.save(
-      this.categoriaRepository.create(categoria),
+      this.categoriaRepository.create(categoriaModel),
     );
   }
 

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.ts
@@ -5,7 +5,7 @@ import { CategoriaModel } from '../../models/categoria.model';
 import { Repository } from 'typeorm';
 import { AtualizaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
-import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
+import { Categoria } from 'src/domain/entities/Categoria';
 
 @Injectable()
 export class CategoriaRepository implements ICategoriaRepository {
@@ -14,7 +14,7 @@ export class CategoriaRepository implements ICategoriaRepository {
     private readonly categoriaRepository: Repository<CategoriaModel>,
   ) {}
 
-  async criaCategoria(categoria: CriaCategoriaDTO) {
+  async criaCategoria(categoria: Categoria) {
     const categoriaModel = new CategoriaModel(categoria);
     return await this.categoriaRepository.save(
       this.categoriaRepository.create(categoriaModel),

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.ts
@@ -35,7 +35,7 @@ export class CategoriaRepository implements ICategoriaRepository {
     return categoriasLista;
   }
 
-  async listaCategoria(id: string): Promise<ListaCategoriaDTO> {
+  async listaCategoria(id: number): Promise<ListaCategoriaDTO> {
     try {
       const categoria = await this.categoriaRepository.findOneOrFail({
         where: { id },
@@ -47,7 +47,7 @@ export class CategoriaRepository implements ICategoriaRepository {
     }
   }
 
-  async atualizaCategoria(id: string, novosDados: AtualizaCategoriaDTO) {
+  async atualizaCategoria(id: number, novosDados: AtualizaCategoriaDTO) {
     const categoria = await this.categoriaRepository.findOneOrFail({
       where: { id },
     });
@@ -55,7 +55,7 @@ export class CategoriaRepository implements ICategoriaRepository {
     return this.categoriaRepository.save(categoria);
   }
 
-  async deletaCategoria(id: string) {
+  async deletaCategoria(id: number) {
     await this.categoriaRepository.findOneOrFail({ where: { id } });
     await this.categoriaRepository.softDelete(id);
   }

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.ts
@@ -5,7 +5,6 @@ import { CategoriaModel } from '../../models/categoria.model';
 import { Repository } from 'typeorm';
 import { AtualizaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
-import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 
 @Injectable()
 export class CategoriaRepository implements ICategoriaRepository {
@@ -14,7 +13,7 @@ export class CategoriaRepository implements ICategoriaRepository {
     private readonly categoriaRepository: Repository<CategoriaModel>,
   ) {}
 
-  async criaCategoria(categoria: CriaCategoriaDTO) {
+  async criaCategoria(categoria: CategoriaModel) {
     return await this.categoriaRepository.save(
       this.categoriaRepository.create(categoria),
     );

--- a/src/adapters/outbound/repositories/categoria/categoria.repository.ts
+++ b/src/adapters/outbound/repositories/categoria/categoria.repository.ts
@@ -5,6 +5,7 @@ import { CategoriaModel } from '../../models/categoria.model';
 import { Repository } from 'typeorm';
 import { AtualizaCategoriaDTO } from '../../../inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
+import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 
 @Injectable()
 export class CategoriaRepository implements ICategoriaRepository {
@@ -13,7 +14,7 @@ export class CategoriaRepository implements ICategoriaRepository {
     private readonly categoriaRepository: Repository<CategoriaModel>,
   ) {}
 
-  async criaCategoria(categoria: CategoriaModel) {
+  async criaCategoria(categoria: CriaCategoriaDTO) {
     return await this.categoriaRepository.save(
       this.categoriaRepository.create(categoria),
     );

--- a/src/adapters/outbound/repositories/produto/produto.repository.ts
+++ b/src/adapters/outbound/repositories/produto/produto.repository.ts
@@ -34,7 +34,7 @@ export class ProdutoRepository implements IProdutoRepository {
     return produtosLista;
   }
 
-  async listaProdutosPorCategoria(id_categoria: string) {
+  async listaProdutosPorCategoria(id_categoria: number) {
     const produtos = await this.produtoRepository.find({
       where: { categoria: { id: id_categoria } },
     });

--- a/src/adapters/outbound/repositories/produto/produto.repository.ts
+++ b/src/adapters/outbound/repositories/produto/produto.repository.ts
@@ -37,9 +37,6 @@ export class ProdutoRepository implements IProdutoRepository {
   async listaProdutosPorCategoria(id_categoria: string) {
     const produtos = await this.produtoRepository.find({
       where: { categoria: { id: id_categoria } },
-      relations: {
-        categoria: true,
-      },
     });
     const produtosLista = produtos.map(
       (produto) =>

--- a/src/adapters/outbound/repositories/produto/produto.repository.ts
+++ b/src/adapters/outbound/repositories/produto/produto.repository.ts
@@ -5,7 +5,6 @@ import { ProdutoModel } from '../../models/produto.model';
 import { Repository } from 'typeorm';
 import { AtualizaProdutoDTO } from '../../../inbound/rest/v1/presenters/dto/produto/AtualizaProduto.dto';
 import { IProdutoRepository } from 'src/domain/ports/produto/IProdutoRepository';
-import { Produto } from 'src/domain/entities/Produto';
 
 @Injectable()
 export class ProdutoRepository implements IProdutoRepository {
@@ -19,11 +18,7 @@ export class ProdutoRepository implements IProdutoRepository {
   }
 
   async listaProdutos() {
-    const produtosSalvos = await this.produtoRepository.find({
-      relations: {
-        categoria: true,
-      },
-    });
+    const produtosSalvos = await this.produtoRepository.find();
     const produtosLista = produtosSalvos.map(
       (produto) =>
         new ListaProdutoDTO(
@@ -32,7 +27,29 @@ export class ProdutoRepository implements IProdutoRepository {
           produto.descricao,
           produto.valorUnitario,
           produto.imagemUrl,
-          produto.categoria?.id ?? null,
+          produto.categoria,
+          produto.ativo,
+        ),
+    );
+    return produtosLista;
+  }
+
+  async listaProdutosPorCategoria(id_categoria: string) {
+    const produtos = await this.produtoRepository.find({
+      where: { categoria: { id: id_categoria } },
+      relations: {
+        categoria: true,
+      },
+    });
+    const produtosLista = produtos.map(
+      (produto) =>
+        new ListaProdutoDTO(
+          produto.id,
+          produto.nome,
+          produto.descricao,
+          produto.valorUnitario,
+          produto.imagemUrl,
+          produto.categoria,
           produto.ativo,
         ),
     );
@@ -53,33 +70,5 @@ export class ProdutoRepository implements IProdutoRepository {
 
   async deletaProduto(id: string) {
     await this.produtoRepository.delete(id);
-  }
-
-  private toProduto(produto: Produto): ProdutoModel {
-    const produtoModel: ProdutoModel = new ProdutoModel();
-
-    produtoModel.id = produto.id;
-    produtoModel.nome = produto.nome;
-    produtoModel.descricao = produto.descricao;
-    produtoModel.categoria = produto.categoria
-      ? Object.assign(produto.categoria)
-      : null;
-    produtoModel.valorUnitario = produto.valorUnitario;
-    produtoModel.imagemUrl = produto.imagemUrl;
-    produtoModel.ativo = produto.ativo;
-
-    return produtoModel;
-  }
-
-  private toCategoriaModel(produtoModel: ProdutoModel): Produto {
-    const produto: Produto = new Produto();
-
-    produto.id = produtoModel.id;
-    produto.nome = produtoModel.nome;
-    produto.descricao = produtoModel.descricao;
-    produto.ativo = produtoModel.ativo;
-    produto.categoria = Object.assign(produtoModel.categoria);
-
-    return produto;
   }
 }

--- a/src/domain/entities/Categoria.ts
+++ b/src/domain/entities/Categoria.ts
@@ -3,7 +3,7 @@
 import { Produto } from './Produto';
 
 interface ICategoria {
-  id: string;
+  id: number;
   nome: string;
   descricao: string;
   createdAt: string;
@@ -14,7 +14,7 @@ interface ICategoria {
 }
 
 export class Categoria {
-  id: string;
+  id: number;
   nome: string;
   descricao: string;
   createdAt: string;

--- a/src/domain/entities/Categoria.ts
+++ b/src/domain/entities/Categoria.ts
@@ -12,14 +12,14 @@ export class Categoria {
   ativo: boolean;
   produtos: Produto[];
   constructor(categoria: {
-    id: number;
-    nome: string;
-    descricao: string;
-    createdAt: string;
-    updatedAt: string;
-    deletedAt: string;
-    ativo: boolean;
-    produtos: Produto[];
+    id?: number;
+    nome?: string;
+    descricao?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    deletedAt?: string;
+    ativo?: boolean;
+    produtos?: Produto[];
   }) {
     this.id = categoria?.id;
     this.nome = categoria?.nome;

--- a/src/domain/entities/Categoria.ts
+++ b/src/domain/entities/Categoria.ts
@@ -2,25 +2,34 @@
 
 import { Produto } from './Produto';
 
-export class Categoria {
-  id: number;
+interface ICategoria {
+  id: string;
   nome: string;
   descricao: string;
   createdAt: string;
   updatedAt: string;
   deletedAt: string;
-  produtos: Produto[];
   ativo: boolean;
+  produtos: Produto[];
+}
 
-  constructor(
-    id?: number,
-    nome?: string,
-    descricao?: string,
-    ativo: boolean = true,
-  ) {
-    this.id = id;
-    this.nome = nome;
-    this.descricao = descricao;
-    this.ativo = ativo;
+export class Categoria {
+  id: string;
+  nome: string;
+  descricao: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  ativo: boolean;
+  produtos: Produto[];
+  constructor(categoria?: Partial<ICategoria>) {
+    this.id = categoria?.id;
+    this.nome = categoria?.nome;
+    this.descricao = categoria?.descricao;
+    this.ativo = categoria?.ativo;
+    this.createdAt = categoria?.createdAt;
+    this.updatedAt = categoria?.updatedAt;
+    this.deletedAt = categoria?.deletedAt;
+    this.produtos = categoria?.produtos;
   }
 }

--- a/src/domain/entities/Categoria.ts
+++ b/src/domain/entities/Categoria.ts
@@ -2,17 +2,6 @@
 
 import { Produto } from './Produto';
 
-interface ICategoria {
-  id: number;
-  nome: string;
-  descricao: string;
-  createdAt: string;
-  updatedAt: string;
-  deletedAt: string;
-  ativo: boolean;
-  produtos: Produto[];
-}
-
 export class Categoria {
   id: number;
   nome: string;
@@ -22,7 +11,16 @@ export class Categoria {
   deletedAt: string;
   ativo: boolean;
   produtos: Produto[];
-  constructor(categoria?: Partial<ICategoria>) {
+  constructor(categoria: {
+    id: number;
+    nome: string;
+    descricao: string;
+    createdAt: string;
+    updatedAt: string;
+    deletedAt: string;
+    ativo: boolean;
+    produtos: Produto[];
+  }) {
     this.id = categoria?.id;
     this.nome = categoria?.nome;
     this.descricao = categoria?.descricao;

--- a/src/domain/entities/Produto.ts
+++ b/src/domain/entities/Produto.ts
@@ -15,12 +15,12 @@ export class Produto {
   ativo: boolean;
 
   constructor(
-    id?: string,
-    nome?: string,
-    descricao?: string,
-    categoria?: Categoria,
-    valorUnitario?: number,
-    imagemUrl?: string,
+    id: string,
+    nome: string,
+    descricao: string,
+    categoria: Categoria,
+    valorUnitario: number,
+    imagemUrl: string,
     ativo: boolean = true,
   ) {
     this.id = id;

--- a/src/domain/ports/categoria/ICategoriaRepository.ts
+++ b/src/domain/ports/categoria/ICategoriaRepository.ts
@@ -1,13 +1,14 @@
 import { CategoriaModel } from '../../../adapters/outbound/models/categoria.model';
 import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto';
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
+import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 
 /**
  * Our domain input port
  */
 
 export interface ICategoriaRepository {
-  criaCategoria(ProdutoModel: CategoriaModel): Promise<CategoriaModel>;
+  criaCategoria(ProdutoModel: CriaCategoriaDTO): Promise<CategoriaModel>;
   listaCategorias(): Promise<ListaCategoriaDTO[]>;
   listaCategoria(id: number): Promise<ListaCategoriaDTO>;
   atualizaCategoria(

--- a/src/domain/ports/categoria/ICategoriaRepository.ts
+++ b/src/domain/ports/categoria/ICategoriaRepository.ts
@@ -1,14 +1,14 @@
 import { CategoriaModel } from '../../../adapters/outbound/models/categoria.model';
 import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto';
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
-import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
+import { Categoria } from 'src/domain/entities/Categoria';
 
 /**
  * Our domain input port
  */
 
 export interface ICategoriaRepository {
-  criaCategoria(categoria: CriaCategoriaDTO): Promise<CategoriaModel>;
+  criaCategoria(categoria: Categoria): Promise<CategoriaModel>;
   listaCategorias(): Promise<ListaCategoriaDTO[]>;
   listaCategoria(id: number): Promise<ListaCategoriaDTO>;
   atualizaCategoria(

--- a/src/domain/ports/categoria/ICategoriaRepository.ts
+++ b/src/domain/ports/categoria/ICategoriaRepository.ts
@@ -10,12 +10,12 @@ import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/ca
 export interface ICategoriaRepository {
   criaCategoria(ProdutoModel: CriaCategoriaDTO): Promise<CategoriaModel>;
   listaCategorias(): Promise<ListaCategoriaDTO[]>;
-  listaCategoria(id: string): Promise<ListaCategoriaDTO>;
+  listaCategoria(id: number): Promise<ListaCategoriaDTO>;
   atualizaCategoria(
-    id: string,
+    id: number,
     novosDados: AtualizaCategoriaDTO,
   ): Promise<CategoriaModel>;
-  deletaCategoria(id: string): Promise<void>;
+  deletaCategoria(id: number): Promise<void>;
 }
 
 export const ICategoriaRepository = Symbol('ICategoriaRepository');

--- a/src/domain/ports/categoria/ICategoriaRepository.ts
+++ b/src/domain/ports/categoria/ICategoriaRepository.ts
@@ -1,16 +1,21 @@
 import { CategoriaModel } from '../../../adapters/outbound/models/categoria.model';
 import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto';
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
+import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 
 /**
  * Our domain input port
  */
 
 export interface ICategoriaRepository {
-  criaCategoria(ProdutoModel: CategoriaModel): Promise<void>;
+  criaCategoria(ProdutoModel: CriaCategoriaDTO): Promise<CategoriaModel>;
   listaCategorias(): Promise<ListaCategoriaDTO[]>;
-  atualizaCategoria(id: number, novosDados: AtualizaCategoriaDTO);
-  deletaCategoria(id: number);
+  listaCategoria(id: string): Promise<ListaCategoriaDTO>;
+  atualizaCategoria(
+    id: string,
+    novosDados: AtualizaCategoriaDTO,
+  ): Promise<CategoriaModel>;
+  deletaCategoria(id: string): Promise<void>;
 }
 
 export const ICategoriaRepository = Symbol('ICategoriaRepository');

--- a/src/domain/ports/categoria/ICategoriaRepository.ts
+++ b/src/domain/ports/categoria/ICategoriaRepository.ts
@@ -8,7 +8,7 @@ import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/ca
  */
 
 export interface ICategoriaRepository {
-  criaCategoria(ProdutoModel: CriaCategoriaDTO): Promise<CategoriaModel>;
+  criaCategoria(categoria: CriaCategoriaDTO): Promise<CategoriaModel>;
   listaCategorias(): Promise<ListaCategoriaDTO[]>;
   listaCategoria(id: number): Promise<ListaCategoriaDTO>;
   atualizaCategoria(

--- a/src/domain/ports/categoria/ICategoriaRepository.ts
+++ b/src/domain/ports/categoria/ICategoriaRepository.ts
@@ -1,14 +1,13 @@
 import { CategoriaModel } from '../../../adapters/outbound/models/categoria.model';
 import { ListaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/ListaCategoria.dto';
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
-import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 
 /**
  * Our domain input port
  */
 
 export interface ICategoriaRepository {
-  criaCategoria(ProdutoModel: CriaCategoriaDTO): Promise<CategoriaModel>;
+  criaCategoria(ProdutoModel: CategoriaModel): Promise<CategoriaModel>;
   listaCategorias(): Promise<ListaCategoriaDTO[]>;
   listaCategoria(id: number): Promise<ListaCategoriaDTO>;
   atualizaCategoria(

--- a/src/domain/ports/categoria/ICategoriaUseCase.ts
+++ b/src/domain/ports/categoria/ICategoriaUseCase.ts
@@ -11,12 +11,12 @@ export interface ICategoriaUseCase {
     dadosCategoria: CriaCategoriaDTO,
   ): Promise<{ mensagem: string; categoria: any }>;
   listaTodas(): Promise<ListaCategoriaDTO[]>;
-  listaUma(id: string): Promise<any>;
+  listaUma(id: number): Promise<any>;
   atualiza(
-    id: string,
+    id: number,
     dadosCategoria: AtualizaCategoriaDTO,
   ): Promise<{ mensagem: string; categoria: any }>;
-  remove(id: string): Promise<{ mensagem: string }>;
+  remove(id: number): Promise<{ mensagem: string }>;
 }
 
 export const ICategoriaUseCase = Symbol('ICategoriaUseCase');

--- a/src/domain/ports/categoria/ICategoriaUseCase.ts
+++ b/src/domain/ports/categoria/ICategoriaUseCase.ts
@@ -7,10 +7,16 @@ import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dt
  */
 
 export interface ICategoriaUseCase {
-  criaNova(dadosCategoria: CriaCategoriaDTO): Promise<void>;
+  criaNova(
+    dadosCategoria: CriaCategoriaDTO,
+  ): Promise<{ mensagem: string; categoria: any }>;
   listaTodas(): Promise<ListaCategoriaDTO[]>;
-  atualiza(id: number, dadosCategoria: AtualizaCategoriaDTO);
-  remove(id: number);
+  listaUma(id: string): Promise<any>;
+  atualiza(
+    id: string,
+    dadosCategoria: AtualizaCategoriaDTO,
+  ): Promise<{ mensagem: string; categoria: any }>;
+  remove(id: string): Promise<{ mensagem: string }>;
 }
 
 export const ICategoriaUseCase = Symbol('ICategoriaUseCase');

--- a/src/domain/ports/produto/IProdutoRepository.ts
+++ b/src/domain/ports/produto/IProdutoRepository.ts
@@ -9,6 +9,7 @@ import { AtualizaProdutoDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/
 export interface IProdutoRepository {
   criaProduto(ProdutoModel: ProdutoModel): Promise<void>;
   listaProdutos(): Promise<ListaProdutoDTO[]>;
+  listaProdutosPorCategoria(id_categoria: string): Promise<ListaProdutoDTO[]>;
   atualizaProduto(id: string, novosDados: AtualizaProdutoDTO);
   deletaProduto(id: string);
 }

--- a/src/domain/ports/produto/IProdutoRepository.ts
+++ b/src/domain/ports/produto/IProdutoRepository.ts
@@ -9,7 +9,7 @@ import { AtualizaProdutoDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/
 export interface IProdutoRepository {
   criaProduto(ProdutoModel: ProdutoModel): Promise<void>;
   listaProdutos(): Promise<ListaProdutoDTO[]>;
-  listaProdutosPorCategoria(id_categoria: string): Promise<ListaProdutoDTO[]>;
+  listaProdutosPorCategoria(id_categoria: number): Promise<ListaProdutoDTO[]>;
   atualizaProduto(id: string, novosDados: AtualizaProdutoDTO);
   deletaProduto(id: string);
 }

--- a/src/domain/ports/produto/IProdutoUseCase.ts
+++ b/src/domain/ports/produto/IProdutoUseCase.ts
@@ -9,7 +9,7 @@ import { AtualizaProdutoDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/
 export interface IProdutoUseCase {
   criaNovo(dadosProduto: CriaProdutoDTO): Promise<void>;
   listaTodos(): Promise<ListaProdutoDTO[]>;
-  listaPorCategoria(categoriaId: string): Promise<ListaProdutoDTO[]>;
+  listaPorCategoria(categoriaId: number): Promise<ListaProdutoDTO[]>;
   atualiza(id: string, dadosProduto: AtualizaProdutoDTO);
   remove(id: string);
 }

--- a/src/domain/ports/produto/IProdutoUseCase.ts
+++ b/src/domain/ports/produto/IProdutoUseCase.ts
@@ -9,6 +9,7 @@ import { AtualizaProdutoDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/
 export interface IProdutoUseCase {
   criaNovo(dadosProduto: CriaProdutoDTO): Promise<void>;
   listaTodos(): Promise<ListaProdutoDTO[]>;
+  listaPorCategoria(categoriaId: string): Promise<ListaProdutoDTO[]>;
   atualiza(id: string, dadosProduto: AtualizaProdutoDTO);
   remove(id: string);
 }

--- a/src/domain/use_cases/categorias/categorias.use_case.spec.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.spec.ts
@@ -128,7 +128,7 @@ describe('CategoriaUseCase', () => {
       const data: CriaCategoriaDTO = {
         ativo: true,
         descricao: 'Lanches para todos os tipos - Atualizado',
-        nome: 'Lanche Atualizado ',
+        nome: 'Lanche Atualizado',
       };
       jest
         .spyOn(categoryRepository, 'criaCategoria')

--- a/src/domain/use_cases/categorias/categorias.use_case.spec.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.spec.ts
@@ -1,0 +1,207 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriaModel } from '../../../adapters/outbound/models/categoria.model';
+import { NotFoundException } from '@nestjs/common';
+import { CriaCategoriaDTO } from '../../../adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
+import { AtualizaCategoriaDTO } from '../../../adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
+import { CategoriaUseCase } from './categorias.use_case';
+import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
+
+const ListaCategoriaEntidade: CategoriaModel[] = [
+  new CategoriaModel({
+    id: '1',
+    ativo: true,
+    descricao: 'Lanches de todos os tipos',
+    nome: 'Lanche',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+  }),
+  new CategoriaModel({
+    id: '2',
+    ativo: true,
+    descricao: 'Bebidas de todos os tipos',
+    nome: 'Bebidas',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+  }),
+  new CategoriaModel({
+    id: '3',
+    ativo: true,
+    descricao: 'Acompanhamento de todos os tipos',
+    nome: 'Acompanhamento',
+    updatedAt: '',
+    createdAt: '',
+    deletedAt: '',
+  }),
+];
+
+const updateCategoriaEntidadeItem = new CategoriaModel({
+  descricao: 'Lanches para todos os tipos - Atualizado',
+  nome: 'Lanche Atualizado ',
+});
+
+describe('CategoriaUseCase', () => {
+  let categoriaUseCase: CategoriaUseCase;
+  let categoryRepository: ICategoriaRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriaUseCase,
+        {
+          provide: ICategoriaRepository,
+          useValue: {
+            listaCategorias: jest
+              .fn()
+              .mockResolvedValue(ListaCategoriaEntidade),
+            listaCategoria: jest
+              .fn()
+              .mockResolvedValue(ListaCategoriaEntidade[0]),
+            criaCategoria: jest.fn().mockReturnValue(ListaCategoriaEntidade[0]),
+            atualizaCategoria: jest
+              .fn()
+              .mockResolvedValue(updateCategoriaEntidadeItem),
+            deletaCategoria: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    categoriaUseCase = module.get<CategoriaUseCase>(CategoriaUseCase);
+    categoryRepository = module.get<ICategoriaRepository>(ICategoriaRepository);
+  });
+
+  it('should be defined', () => {
+    expect(categoriaUseCase).toBeDefined();
+    expect(categoryRepository).toBeDefined();
+  });
+
+  describe('listaTodas', () => {
+    it('Deve ser retornada uma lista de entidades de todas as categorias', async () => {
+      const result = await categoriaUseCase.listaTodas();
+      expect(result).toEqual(ListaCategoriaEntidade);
+      expect(categoryRepository.listaCategorias).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser retornada uma exceção em caso de erro', () => {
+      jest
+        .spyOn(categoryRepository, 'listaCategorias')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaUseCase.listaTodas()).rejects.toThrowError();
+    });
+  });
+
+  describe('listaUma', () => {
+    it('Deve ser retornado um item da entidade categoria', async () => {
+      const result = await categoriaUseCase.listaUma('1');
+      expect(result).toEqual(ListaCategoriaEntidade[0]);
+      expect(categoryRepository.listaCategoria).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção (not found exception) em caso de erro', () => {
+      jest
+        .spyOn(categoryRepository, 'listaCategoria')
+        .mockRejectedValueOnce(new NotFoundException());
+      expect(categoriaUseCase.listaUma('1')).rejects.toThrowError(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('criaNova', () => {
+    it('Deve criar uma categoria com sucesso', async () => {
+      const data: CriaCategoriaDTO = {
+        ativo: true,
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const result = await categoriaUseCase.criaNova(data);
+      expect(result).toEqual({
+        categoria: ListaCategoriaEntidade[0],
+        mensagem: 'categoria criada com sucesso',
+      });
+      expect(categoryRepository.criaCategoria).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve ser lançada uma exceção em caso de erro', () => {
+      const data: CriaCategoriaDTO = {
+        ativo: true,
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      jest
+        .spyOn(categoryRepository, 'criaCategoria')
+        .mockRejectedValueOnce(new Error());
+      expect(categoriaUseCase.criaNova(data)).rejects.toThrowError();
+    });
+  });
+
+  describe('atualiza', () => {
+    it('Deve ser atualiza uma categoria com sucesso', async () => {
+      const dados = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const categoriaAtualizar = new AtualizaCategoriaDTO(dados);
+      const result = await categoriaUseCase.atualiza('1', categoriaAtualizar);
+      expect(result).toEqual({
+        categoria: updateCategoriaEntidadeItem,
+        mensagem: 'categoria atualizada com sucesso',
+      });
+      expect(categoryRepository.listaCategoria).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve lançar uma not found exception se a categoria não existir', async () => {
+      const dados = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const categoriaAtualizar = new AtualizaCategoriaDTO(dados);
+      jest
+        .spyOn(categoryRepository, 'listaCategoria')
+        .mockRejectedValueOnce(new NotFoundException());
+      expect(
+        categoriaUseCase.atualiza('1', categoriaAtualizar),
+      ).rejects.toThrowError(NotFoundException);
+    });
+
+    it('Deve lançar uma exceção quando não conseguir salvar', () => {
+      const dados = {
+        descricao: 'Lanches para todos os tipos - Atualizado',
+        nome: 'Lanche Atualizado ',
+      };
+      const categoriaAtualizar = new AtualizaCategoriaDTO(dados);
+      jest
+        .spyOn(categoryRepository, 'atualizaCategoria')
+        .mockRejectedValueOnce(new Error());
+      expect(
+        categoriaUseCase.atualiza('1', categoriaAtualizar),
+      ).rejects.toThrowError();
+    });
+  });
+
+  describe('remove', () => {
+    it('Deve ser removida a entidade da categoria com sucesso', async () => {
+      const result = await categoriaUseCase.remove('1');
+      expect(result).toEqual({ mensagem: 'categoria removida com sucesso' });
+      expect(categoryRepository.listaCategoria).toHaveBeenCalledTimes(1);
+    });
+
+    it('Deve lançar uma not found exception se a categoria não existir', async () => {
+      jest
+        .spyOn(categoryRepository, 'listaCategoria')
+        .mockRejectedValueOnce(new NotFoundException());
+      expect(categoriaUseCase.remove('1')).rejects.toThrowError(
+        NotFoundException,
+      );
+    });
+
+    it('Deve lançar uma exception se retornar um erro ao tentar remover a categoria', async () => {
+      jest
+        .spyOn(categoryRepository, 'deletaCategoria')
+        .mockRejectedValueOnce(new NotFoundException());
+      expect(categoriaUseCase.remove('1')).rejects.toThrowError();
+    });
+  });
+});

--- a/src/domain/use_cases/categorias/categorias.use_case.spec.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriaModel } from '../../../adapters/outbound/models/categoria.model';
 import { NotFoundException } from '@nestjs/common';
-import { CriaCategoriaDTO } from '../../../adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 import { AtualizaCategoriaDTO } from '../../../adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { CategoriaUseCase } from './categorias.use_case';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
@@ -111,12 +110,7 @@ describe('CategoriaUseCase', () => {
 
   describe('criaNova', () => {
     it('Deve criar uma categoria com sucesso', async () => {
-      const data: CriaCategoriaDTO = {
-        ativo: true,
-        descricao: 'Lanches para todos os tipos - Atualizado',
-        nome: 'Lanche Atualizado ',
-      };
-      const result = await categoriaUseCase.criaNova(data);
+      const result = await categoriaUseCase.criaNova(ListaCategoriaEntidade[0]);
       expect(result).toEqual({
         categoria: ListaCategoriaEntidade[0],
         mensagem: 'categoria criada com sucesso',
@@ -125,10 +119,15 @@ describe('CategoriaUseCase', () => {
     });
 
     it('Deve ser lançada uma exceção em caso de erro', () => {
-      const data: CriaCategoriaDTO = {
+      const data: CategoriaModel = {
         ativo: true,
         descricao: 'Lanches para todos os tipos - Atualizado',
         nome: 'Lanche Atualizado',
+        id: 0,
+        createdAt: '',
+        updatedAt: '',
+        deletedAt: '',
+        produtos: [],
       };
       jest
         .spyOn(categoryRepository, 'criaCategoria')

--- a/src/domain/use_cases/categorias/categorias.use_case.spec.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.spec.ts
@@ -8,7 +8,7 @@ import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepos
 
 const ListaCategoriaEntidade: CategoriaModel[] = [
   new CategoriaModel({
-    id: '1',
+    id: 1,
     ativo: true,
     descricao: 'Lanches de todos os tipos',
     nome: 'Lanche',
@@ -17,7 +17,7 @@ const ListaCategoriaEntidade: CategoriaModel[] = [
     deletedAt: '',
   }),
   new CategoriaModel({
-    id: '2',
+    id: 2,
     ativo: true,
     descricao: 'Bebidas de todos os tipos',
     nome: 'Bebidas',
@@ -26,7 +26,7 @@ const ListaCategoriaEntidade: CategoriaModel[] = [
     deletedAt: '',
   }),
   new CategoriaModel({
-    id: '3',
+    id: 3,
     ativo: true,
     descricao: 'Acompanhamento de todos os tipos',
     nome: 'Acompanhamento',
@@ -94,7 +94,7 @@ describe('CategoriaUseCase', () => {
 
   describe('listaUma', () => {
     it('Deve ser retornado um item da entidade categoria', async () => {
-      const result = await categoriaUseCase.listaUma('1');
+      const result = await categoriaUseCase.listaUma(1);
       expect(result).toEqual(ListaCategoriaEntidade[0]);
       expect(categoryRepository.listaCategoria).toHaveBeenCalledTimes(1);
     });
@@ -103,7 +103,7 @@ describe('CategoriaUseCase', () => {
       jest
         .spyOn(categoryRepository, 'listaCategoria')
         .mockRejectedValueOnce(new NotFoundException());
-      expect(categoriaUseCase.listaUma('1')).rejects.toThrowError(
+      expect(categoriaUseCase.listaUma(1)).rejects.toThrowError(
         NotFoundException,
       );
     });
@@ -144,7 +144,7 @@ describe('CategoriaUseCase', () => {
         nome: 'Lanche Atualizado ',
       };
       const categoriaAtualizar = new AtualizaCategoriaDTO(dados);
-      const result = await categoriaUseCase.atualiza('1', categoriaAtualizar);
+      const result = await categoriaUseCase.atualiza(1, categoriaAtualizar);
       expect(result).toEqual({
         categoria: updateCategoriaEntidadeItem,
         mensagem: 'categoria atualizada com sucesso',
@@ -162,7 +162,7 @@ describe('CategoriaUseCase', () => {
         .spyOn(categoryRepository, 'listaCategoria')
         .mockRejectedValueOnce(new NotFoundException());
       expect(
-        categoriaUseCase.atualiza('1', categoriaAtualizar),
+        categoriaUseCase.atualiza(1, categoriaAtualizar),
       ).rejects.toThrowError(NotFoundException);
     });
 
@@ -176,14 +176,14 @@ describe('CategoriaUseCase', () => {
         .spyOn(categoryRepository, 'atualizaCategoria')
         .mockRejectedValueOnce(new Error());
       expect(
-        categoriaUseCase.atualiza('1', categoriaAtualizar),
+        categoriaUseCase.atualiza(1, categoriaAtualizar),
       ).rejects.toThrowError();
     });
   });
 
   describe('remove', () => {
     it('Deve ser removida a entidade da categoria com sucesso', async () => {
-      const result = await categoriaUseCase.remove('1');
+      const result = await categoriaUseCase.remove(1);
       expect(result).toEqual({ mensagem: 'categoria removida com sucesso' });
       expect(categoryRepository.listaCategoria).toHaveBeenCalledTimes(1);
     });
@@ -192,7 +192,7 @@ describe('CategoriaUseCase', () => {
       jest
         .spyOn(categoryRepository, 'listaCategoria')
         .mockRejectedValueOnce(new NotFoundException());
-      expect(categoriaUseCase.remove('1')).rejects.toThrowError(
+      expect(categoriaUseCase.remove(1)).rejects.toThrowError(
         NotFoundException,
       );
     });
@@ -201,7 +201,7 @@ describe('CategoriaUseCase', () => {
       jest
         .spyOn(categoryRepository, 'deletaCategoria')
         .mockRejectedValueOnce(new NotFoundException());
-      expect(categoriaUseCase.remove('1')).rejects.toThrowError();
+      expect(categoriaUseCase.remove(1)).rejects.toThrowError();
     });
   });
 });

--- a/src/domain/use_cases/categorias/categorias.use_case.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.ts
@@ -3,6 +3,7 @@ import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/ca
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
+import { CategoriaModel } from 'src/adapters/outbound/models/categoria.model';
 
 @Injectable()
 export class CategoriaUseCase implements ICategoriaUseCase {
@@ -12,8 +13,9 @@ export class CategoriaUseCase implements ICategoriaUseCase {
   ) {}
 
   async criaNova(dadosCategoria: CriaCategoriaDTO) {
+    const categoriaModel = new CategoriaModel(dadosCategoria);
     const categoria =
-      await this.categoriaRepository.criaCategoria(dadosCategoria);
+      await this.categoriaRepository.criaCategoria(categoriaModel);
     return {
       mensagem: 'categoria criada com sucesso',
       categoria: categoria,

--- a/src/domain/use_cases/categorias/categorias.use_case.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.ts
@@ -3,6 +3,7 @@ import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/ca
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
+import { Categoria } from 'src/domain/entities/Categoria';
 
 @Injectable()
 export class CategoriaUseCase implements ICategoriaUseCase {
@@ -12,11 +13,12 @@ export class CategoriaUseCase implements ICategoriaUseCase {
   ) {}
 
   async criaNova(dadosCategoria: CriaCategoriaDTO) {
-    const categoria =
-      await this.categoriaRepository.criaCategoria(dadosCategoria);
+    const categoria = new Categoria(dadosCategoria);
+    const novaCategoria =
+      await this.categoriaRepository.criaCategoria(categoria);
     return {
       mensagem: 'categoria criada com sucesso',
-      categoria: categoria,
+      categoria: novaCategoria,
     };
   }
 

--- a/src/domain/use_cases/categorias/categorias.use_case.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { CategoriaModel } from 'src/adapters/outbound/models/categoria.model';
 import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/CriaCategoria.dto';
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
@@ -13,21 +12,24 @@ export class CategoriaUseCase implements ICategoriaUseCase {
   ) {}
 
   async criaNova(dadosCategoria: CriaCategoriaDTO) {
-    const categoria = new CategoriaModel();
-
-    categoria.nome = dadosCategoria.nome;
-    categoria.descricao = dadosCategoria.descricao;
-    categoria.ativo = dadosCategoria.ativo;
-
-    const categoriaCadastrado = this.categoriaRepository.criaCategoria(categoria);
-    return categoriaCadastrado;
+    const categoria =
+      await this.categoriaRepository.criaCategoria(dadosCategoria);
+    return {
+      mensagem: 'categoria criada com sucesso',
+      categoria: categoria,
+    };
   }
 
   async listaTodas() {
     return this.categoriaRepository.listaCategorias();
   }
 
-  async atualiza(id: number, dadosCategoria: AtualizaCategoriaDTO) {
+  async listaUma(id: string) {
+    return this.categoriaRepository.listaCategoria(id);
+  }
+
+  async atualiza(id: string, dadosCategoria: AtualizaCategoriaDTO) {
+    await this.categoriaRepository.listaCategoria(id);
     const categoriaAlterada = await this.categoriaRepository.atualizaCategoria(
       id,
       dadosCategoria,
@@ -39,12 +41,11 @@ export class CategoriaUseCase implements ICategoriaUseCase {
     };
   }
 
-  async remove(id: number) {
-    const categoriaRemovida = await this.categoriaRepository.deletaCategoria(id);
-
+  async remove(id: string) {
+    await this.categoriaRepository.listaCategoria(id);
+    await this.categoriaRepository.deletaCategoria(id);
     return {
       mensagem: 'categoria removida com sucesso',
-      categoria: categoriaRemovida,
     };
   }
 }

--- a/src/domain/use_cases/categorias/categorias.use_case.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.ts
@@ -25,7 +25,7 @@ export class CategoriaUseCase implements ICategoriaUseCase {
   }
 
   async listaUma(id: string) {
-    return this.categoriaRepository.listaCategoria(id);
+    return await this.categoriaRepository.listaCategoria(id);
   }
 
   async atualiza(id: string, dadosCategoria: AtualizaCategoriaDTO) {

--- a/src/domain/use_cases/categorias/categorias.use_case.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.ts
@@ -3,7 +3,6 @@ import { CriaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/ca
 import { AtualizaCategoriaDTO } from 'src/adapters/inbound/rest/v1/presenters/dto/categoria/AtualizaCategoria.dto';
 import { ICategoriaUseCase } from 'src/domain/ports/categoria/ICategoriaUseCase';
 import { ICategoriaRepository } from 'src/domain/ports/categoria/ICategoriaRepository';
-import { CategoriaModel } from 'src/adapters/outbound/models/categoria.model';
 
 @Injectable()
 export class CategoriaUseCase implements ICategoriaUseCase {
@@ -13,9 +12,8 @@ export class CategoriaUseCase implements ICategoriaUseCase {
   ) {}
 
   async criaNova(dadosCategoria: CriaCategoriaDTO) {
-    const categoriaModel = new CategoriaModel(dadosCategoria);
     const categoria =
-      await this.categoriaRepository.criaCategoria(categoriaModel);
+      await this.categoriaRepository.criaCategoria(dadosCategoria);
     return {
       mensagem: 'categoria criada com sucesso',
       categoria: categoria,

--- a/src/domain/use_cases/categorias/categorias.use_case.ts
+++ b/src/domain/use_cases/categorias/categorias.use_case.ts
@@ -24,11 +24,11 @@ export class CategoriaUseCase implements ICategoriaUseCase {
     return this.categoriaRepository.listaCategorias();
   }
 
-  async listaUma(id: string) {
+  async listaUma(id: number) {
     return await this.categoriaRepository.listaCategoria(id);
   }
 
-  async atualiza(id: string, dadosCategoria: AtualizaCategoriaDTO) {
+  async atualiza(id: number, dadosCategoria: AtualizaCategoriaDTO) {
     await this.categoriaRepository.listaCategoria(id);
     const categoriaAlterada = await this.categoriaRepository.atualizaCategoria(
       id,
@@ -41,7 +41,7 @@ export class CategoriaUseCase implements ICategoriaUseCase {
     };
   }
 
-  async remove(id: string) {
+  async remove(id: number) {
     await this.categoriaRepository.listaCategoria(id);
     await this.categoriaRepository.deletaCategoria(id);
     return {

--- a/src/domain/use_cases/produtos/produtos.use_case.ts
+++ b/src/domain/use_cases/produtos/produtos.use_case.ts
@@ -19,7 +19,7 @@ export class ProdutoUseCase implements IProdutoUseCase {
     produto.descricao = dadosProduto.descricao;
     produto.valorUnitario = dadosProduto.valorUnitario;
     produto.imagemUrl = dadosProduto.imagemUrl;
-    produto.categoria = <any>{ id_categoria: dadosProduto.idCategoria };
+    produto.categoria = <any>{ id: dadosProduto.idCategoria };
     produto.ativo = dadosProduto.ativo;
 
     const produtoCadastrado = this.produtoRepository.criaProduto(produto);
@@ -30,7 +30,7 @@ export class ProdutoUseCase implements IProdutoUseCase {
     return this.produtoRepository.listaProdutos();
   }
 
-  async listaPorCategoria(categoriaId: string) {
+  async listaPorCategoria(categoriaId: number) {
     return await this.produtoRepository.listaProdutosPorCategoria(categoriaId);
   }
 

--- a/src/domain/use_cases/produtos/produtos.use_case.ts
+++ b/src/domain/use_cases/produtos/produtos.use_case.ts
@@ -19,7 +19,7 @@ export class ProdutoUseCase implements IProdutoUseCase {
     produto.descricao = dadosProduto.descricao;
     produto.valorUnitario = dadosProduto.valorUnitario;
     produto.imagemUrl = dadosProduto.imagemUrl;
-    produto.categoria = <any>{ id: dadosProduto.idCategoria };
+    produto.categoria = <any>{ id_categoria: dadosProduto.idCategoria };
     produto.ativo = dadosProduto.ativo;
 
     const produtoCadastrado = this.produtoRepository.criaProduto(produto);
@@ -28,6 +28,10 @@ export class ProdutoUseCase implements IProdutoUseCase {
 
   async listaTodos() {
     return this.produtoRepository.listaProdutos();
+  }
+
+  async listaPorCategoria(categoriaId: string) {
+    return await this.produtoRepository.listaProdutosPorCategoria(categoriaId);
   }
 
   async atualiza(id: string, dadosProduto: AtualizaProdutoDTO) {


### PR DESCRIPTION
Criar endpoint para retornar os produtos cadastrados em uma categoria.
Endpoint criado: http://localhost:3000/produtos/categoria/id

Categorias cadastradas para teste:
![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/28732069/8e80ef10-1921-4b9f-8fc7-84e33c861581)

Produtos cadastrados para teste:
![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/28732069/262330d7-0efd-4ee0-9f45-66fadf3084f0)

Execução via postman
![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/28732069/4853cb7e-5cf4-4f83-8a35-451ecf1330c4)


Observação: Adicionei tests unitários para controller, use_case e repository de Categorias.
Porém vejo que ainda temos testes e validações a serem feitas tanto em Categoria quanto em Produtos.
![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/28732069/799d940b-e21f-4a69-a351-e17b8c02a2ed)


