### PR TITLE
ci: Remove o @jonasaraldi do CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://help.github.com/articles/about-codeowners/
 
 # Default owners for everything in the repo
-*       @jonasaraldi @dannevesdantas @joao0812 @RafaelFerSilva @anaplopes
+*       @dannevesdantas @joao0812 @RafaelFerSilva @anaplopes


### PR DESCRIPTION
Removendo o @jonasaraldi do CODEOWNERS para que ele não fique recebendo toda hora notificação de PR.