### PR TITLE
fix: Exibe categoria null qdo a mesma for excluida

### DIFF
--- a/src/domain/use_cases/produto/produto.use_case.ts
+++ b/src/domain/use_cases/produto/produto.use_case.ts
@@ -179,18 +179,21 @@ export class ProdutoUseCase implements IProdutoUseCase {
   async listarProdutos(): Promise<ProdutoDTO[] | []> {
     const result = await this.produtoRepository.listarProdutos();
     const listaProdutosDTO = result.map((produto: ProdutoModel) => {
-      const categoriaDTO = new CategoriaDTO();
-      categoriaDTO.id = produto.categoria.id;
-      categoriaDTO.nome = produto.categoria.nome;
-      categoriaDTO.descricao = produto.categoria.descricao;
-
       const produtoDTO = new ProdutoDTO();
       produtoDTO.id = produto.id;
       produtoDTO.nome = produto.nome;
       produtoDTO.descricao = produto.descricao;
       produtoDTO.valorUnitario = produto.valorUnitario;
       produtoDTO.imagemUrl = produto.imagemUrl;
-      produtoDTO.categoria = categoriaDTO;
+      produtoDTO.categoria = null;
+
+      if (produto.categoria) {
+        const categoriaDTO = new CategoriaDTO();
+        categoriaDTO.id = produto.categoria.id;
+        categoriaDTO.nome = produto.categoria.nome;
+        categoriaDTO.descricao = produto.categoria.descricao;
+        produtoDTO.categoria = categoriaDTO;
+      }
 
       return produtoDTO;
     });


### PR DESCRIPTION
Pessoal, estava mexendo no Tech Challenge e sem querer acabei encontrando outro pequeno bug.

Ao consultar produtos em GET http://localhost:3000/produto se a categoria de algum produto tiver sido excluída, dará o seguinte erro:

<img width="546" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/5115895/0eed898c-8a5c-4e01-940c-22bb46339c9e">

<img width="887" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/5115895/0d668ed8-6801-4853-b1c8-395bd0bad67f">

Fiz a correção. Agora, caso a categoria houver sido excluída, não dará mais erro ao consultar o produto e será exibido `categoria: null` na response: assim:

<img width="794" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-backend-fase01/assets/5115895/d593f4dc-7a7f-4d02-8adb-94f21c04e051">

Poderiam analisar pfv?

Acho interessante a gente consertar, já que é simples para arrumar. Assim evitamos surpresas na hora do teste pelo professor. 